### PR TITLE
Make sure Hugging Face download stats work, better discoverability

### DIFF
--- a/modeling/maskgit.py
+++ b/modeling/maskgit.py
@@ -26,8 +26,10 @@ import math
 import torch.utils.checkpoint
 from transformers import BertConfig, BertModel
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class ImageBert(nn.Module):
+
+class ImageBert(nn.Module, PyTorchModelHubMixin):
     def __init__(self, config):
         super().__init__()
         self.config = config

--- a/modeling/maskgit.py
+++ b/modeling/maskgit.py
@@ -26,7 +26,10 @@ import math
 import torch.utils.checkpoint
 from transformers import BertConfig, BertModel
 
+import json
 from huggingface_hub import PyTorchModelHubMixin
+from omegaconf import OmegaConf
+from pathlib import Path
 
 
 class ImageBert(nn.Module, PyTorchModelHubMixin):
@@ -58,6 +61,17 @@ class ImageBert(nn.Module, PyTorchModelHubMixin):
         
         self.model.post_init()
 
+    def _save_pretrained(self, save_directory: Path) -> None:
+        """Save weights and config to a local directory."""
+        # Assume 'self.config' is your DictConfig object
+        # Convert to a regular dictionary
+        dict_config = OmegaConf.to_container(self.config)
+        # Save as JSON
+        file_path = Path(save_directory) / "config.json"
+        with open(file_path, 'w') as json_file:
+            json.dump(dict_config, json_file, indent=4)
+        super().save_pretrained(save_directory)
+    
     def forward(self, input_ids=None, condition=None, cond_drop_prob=0.1):
         # Token space:
         #  [0, codebook_size - 1]                       : those are the learned quantized image tokens

--- a/modeling/maskgit.py
+++ b/modeling/maskgit.py
@@ -32,7 +32,7 @@ from omegaconf import OmegaConf
 from pathlib import Path
 
 
-class ImageBert(nn.Module, PyTorchModelHubMixin):
+class ImageBert(nn.Module, PyTorchModelHubMixin, tags=["arxiv:2304.12244"], pipeline_tag="text_to_image", license="mit"):
     def __init__(self, config):
 
         if isinstance(config, dict):

--- a/modeling/maskgit.py
+++ b/modeling/maskgit.py
@@ -34,6 +34,10 @@ from pathlib import Path
 
 class ImageBert(nn.Module, PyTorchModelHubMixin):
     def __init__(self, config):
+
+        if isinstance(config, dict):
+            config = OmegaConf.create(config)
+
         super().__init__()
         self.config = config
         self.target_codebook_size = config.model.vq_model.codebook_size

--- a/modeling/maskgit.py
+++ b/modeling/maskgit.py
@@ -70,7 +70,7 @@ class ImageBert(nn.Module, PyTorchModelHubMixin):
         file_path = Path(save_directory) / "config.json"
         with open(file_path, 'w') as json_file:
             json.dump(dict_config, json_file, indent=4)
-        super().save_pretrained(save_directory)
+        super()._save_pretrained(save_directory)
     
     def forward(self, input_ids=None, condition=None, cond_drop_prob=0.1):
         # Token space:

--- a/modeling/titok.py
+++ b/modeling/titok.py
@@ -25,7 +25,10 @@ from .maskgit_vqgan import Decoder as Pixel_Decoder
 from .maskgit_vqgan import VectorQuantizer as Pixel_Quantizer
 from omegaconf import OmegaConf
 
-class TiTok(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+
+class TiTok(nn.Module, PyTorchModelHubMixin):
     def __init__(self, config):
         super().__init__()
         self.config = config

--- a/modeling/titok.py
+++ b/modeling/titok.py
@@ -23,7 +23,9 @@ from .blocks import TiTokEncoder, TiTokDecoder
 from .quantizer import VectorQuantizer
 from .maskgit_vqgan import Decoder as Pixel_Decoder
 from .maskgit_vqgan import VectorQuantizer as Pixel_Quantizer
+import json
 from omegaconf import OmegaConf
+from pathlib import Path
 
 from huggingface_hub import PyTorchModelHubMixin
 

--- a/modeling/titok.py
+++ b/modeling/titok.py
@@ -28,8 +28,12 @@ from omegaconf import OmegaConf
 from huggingface_hub import PyTorchModelHubMixin
 
 
-class TiTok(nn.Module, PyTorchModelHubMixin):
+class TiTok(nn.Module, PyTorchModelHubMixin, tags=["arxiv:2304.12244", "image-tokenization"], license="mit"):
     def __init__(self, config):
+
+        if isinstance(config, dict):
+            config = OmegaConf.create(config)
+
         super().__init__()
         self.config = config
         self.encoder = TiTokEncoder(config)
@@ -59,6 +63,17 @@ class TiTok(nn.Module, PyTorchModelHubMixin):
              "num_res_blocks": 2,
              "resolution": 256,
              "z_channels": 256}))
+        
+    def _save_pretrained(self, save_directory: Path) -> None:
+        """Save weights and config to a local directory."""
+        # Assume 'self.config' is your DictConfig object
+        # Convert to a regular dictionary
+        dict_config = OmegaConf.to_container(self.config)
+        # Save as JSON
+        file_path = Path(save_directory) / "config.json"
+        with open(file_path, 'w') as json_file:
+            json.dump(dict_config, json_file, indent=4)
+        super()._save_pretrained(save_directory)
 
     def _init_weights(self, module):
         """ Initialize the weights.


### PR DESCRIPTION
Hi,

Thanks for this nice work! Found it from https://huggingface.co/papers/2406.07550. I see you're already leveraging `hf_hub_download` which is nice 🤗 

This PR is a small QoL improvement to make download stats work for your models. Basically, we recommend to push checkpoints to individual model repositories, and then leverage the [Mixin](https://huggingface.co/docs/hub/models-uploading#upload-a-pytorch-model-using-huggingfacehub) class which pushes a `config.json` along with `safetensors` weights to the hub. The [download stats](https://huggingface.co/docs/hub/models-download-stats) are by default based on config.json.

Usage is as follows:

```
from modeling.maskgit import ImageBert

model = ImageBert.from_pretrained("nielsr/titok-generator")

# optionally, one can push a model to the hub
model.push_to_hub("nielsr/my-awesome-titok-model")
```
The same can be done for the tokenizer.

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. The corresponding model is here for now: https://huggingface.co/nielsr/titok-generator. We could move all checkpoints to your personal user account if you're interested.

Would you be interested in this integration?

Kind regards,

Niels